### PR TITLE
Fix Model Info Displays in Tool Controller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
         tags: ${{ env.tags }}
         build-args: |
           MODEL_NAME=${{ env.MODEL_NAME }}
+          CONFIG_NAME=${{ env.CONFIG_NAME }}
         labels: |
           org.opencontainers.image.created=${{ env.created }}
           org.opencontainers.image.source=${{ github.repositoryUrl }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,9 @@ services:
     image: docker.synapse.org/syn22277123/phi-annotator-huggingface
     build:
       context: server
-      # args:
-        # MODEL_NAME: "dslim/bert-base-NER"
+      args:
+        MODEL_NAME: "dslim/bert-base-NER-uncased"
+        CONFIG_NAME: "bert-base-ner-uncased"
     container_name: phi-annotator
     networks:
       - nlpsandbox-internal

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.9.6-slim-buster
 
-ARG MODEL_NAME="dslim/bert-base-NER"
+ARG MODEL_NAME
+ARG CONFIG_NAME
 
 ENV APP_DIR=/opt/app
+ENV CONFIG_NAME=${CONFIG_NAME}
 
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 

--- a/server/openapi_server/config.py
+++ b/server/openapi_server/config.py
@@ -1,16 +1,10 @@
 import os
-from enum import Enum
+
 
 defaultValues = {
-    "CONFIG_NAME": "",
-    "MODEL_NAME": ""
+    "CONFIG_NAME": "<UNSPECIFIED>",
+    "MODEL_NAME": "<UNSPECIFIED>"
 }
-
-
-class ConfigName(Enum):
-    BERT_BASE_NER = "bert-base-ner"
-    BERT_BASE_NER_UNCASED = "bert-base-ner-uncased"
-    BERT_LARGE_NER = "bert-large-ner"
 
 
 class AbstractConfig(object):
@@ -32,10 +26,9 @@ class AbstractConfig(object):
 
 
 class Config(AbstractConfig):
-    """
-    This class is used to provide coniguration values to the application, first
-    using environment variables and if not found, defaulting to those values
-    provided in the defaultValues dictionary above.
+    """This class is used to provide configuration values to the application,
+    first using environment variables and if not found, defaulting to those
+    values provided in the defaultValues dictionary above.
     """
 
     @property

--- a/server/openapi_server/controllers/tool_controller.py
+++ b/server/openapi_server/controllers/tool_controller.py
@@ -18,7 +18,7 @@ def get_tool():  # noqa: E501
         version="1.0.0",
         license=License.APACHE_2_0,
         repository="github:nlpsandbox/phi-annotator-huggingface",
-        description="Hugging Face PHI annotator ({config.model_name})",
+        description=f"Hugging Face PHI annotator ({config.model_name})",
         author="NLP Sandbox Team",
         author_email="team@nlpsandbox.io",
         url="https://github.com/nlpsandbox/phi-annotator-huggingface",


### PR DESCRIPTION
It turns out the `CONFIG_NAME` build arg wasn't getting passed through to the ENV inside the docker container. Whoops! Fingers crossed, will work now.